### PR TITLE
Update README.md - Fixed link to the Getting Started page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A Chrome extension which helps you to control a Youtube video using keyboard shortcuts.
 
 ## Installation
-Follow the steps given [here](developer.chrome.com/extensions/getstarted#unpacked)
+Follow the steps given [here](https://developer.chrome.com/extensions/getstarted#unpacked)
 
 ## Keys
 Use the following keys for controlling a youtube video running in chrome, from anywhere on the desktop.


### PR DESCRIPTION
README.md was referencing the URL - "https://github.com/asdoc/youtube-shortcuts/blob/master/developer.chrome.com/extensions/getstarted#unpacked" instead of "https://developer.chrome.com/extensions/getstarted#unpacked".
