### PR TITLE
The skip ad action now works.

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -67,7 +67,7 @@ function play_pause_video() {
 }
 
 function skip_ads() {
-    execute_inline_code("var skipButton = document.getElementsByClassName('ytp-ad-skip-button ytp-button')[0]; skipButton.click();");
+    execute_inline_code("var skipButton = document.getElementsByClassName('videoAdUiSkipButton videoAdUiAction videoAdUiFixedPaddingSkipButton')[0]; skipButton.click();");
 }
 
 chrome.commands.onCommand.addListener(function(command) {


### PR DESCRIPTION
Fixed the name of the class for skip ad button. Looks like it was changed in the recent youtube UI update.